### PR TITLE
moving from old IPFS dependencies to boxo

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -198,7 +198,8 @@ func Hex64ToBase64(key string) (string, error) {
 
 	// marshal
 	pbmes := new(pb.PrivateKey)
-	pbmes.Type = pb.KeyType_Secp256k1
+	keyType := pb.KeyType_Secp256k1
+	pbmes.Type = &keyType
 	pbmes.Data = dst
 	marshaledKey, err := proto.Marshal(pbmes)
 	if err != nil {


### PR DESCRIPTION
As part of the IPFS SDK dependencies migration to boxo, this update is necessary to move to boxo SDK for BTFS. I'll be doing other Pull Request in several BTFS repos to safely move to boxo and support newer golang releases
